### PR TITLE
Add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.3",
   "license": "MIT",
   "main": "src/index.js",
+  "repository": "usmanyunusov/webpack-webmanifest-plugin",
   "scripts": {
     "lint": "prettier \"{**/*,*}.js\" --write"
   },


### PR DESCRIPTION
Adding `repository` key will add link to GitHub repo to [package’s npm page](https://www.npmjs.com/package/webpack-webmanifest-plugin) and to output of tools like `yarn upgrade-interactive`